### PR TITLE
一時的なファイル名の編集とリネーム処理の分離

### DIFF
--- a/FileRenamer/Models/ExFileSystemInfo.cs
+++ b/FileRenamer/Models/ExFileSystemInfo.cs
@@ -33,7 +33,8 @@ namespace FileRenamer.Models {
 
         public string Extension => (IsDirectory) ? "/" : fileSystemInfo.Extension;
 
-        public string AfterName { get; set; }
+        public string AfterName { get => afterName; set => SetProperty(ref afterName, value); }
+        private string afterName = "";
 
         public string ParentDirectoryName => Directory.GetParent(fileSystemInfo.FullName).Name;
 

--- a/FileRenamer/Models/Renamer.cs
+++ b/FileRenamer/Models/Renamer.cs
@@ -27,7 +27,6 @@ namespace FileRenamer.Models {
                     f.AfterName += str;
                 }
 
-                f.rename();
             });
         } 
 
@@ -38,7 +37,6 @@ namespace FileRenamer.Models {
         public void attachStringToEnd(string str) {
             Files.ForEach(f => {
                 f.AfterName += str;
-                f.rename();
             });
         }
 
@@ -59,13 +57,16 @@ namespace FileRenamer.Models {
                     f.AfterName += countString;
                 }
 
-                f.rename();
                 startCount++;
             });
         }
 
         public void attachNumberToEnd(int startCount = 0, int digits = 1) {
             insertNumber(int.MaxValue, startCount, digits);
+        }
+
+        public void rename() {
+            Files.ForEach(f => f.rename());
         }
     }
 }

--- a/FileRenamer/ViewModels/MainWindowViewModel.cs
+++ b/FileRenamer/ViewModels/MainWindowViewModel.cs
@@ -52,5 +52,15 @@ namespace FileRenamer.ViewModels
         #endregion
 
 
+        public DelegateCommand RenameCommand {
+            #region
+            get => renameCommand ?? (renameCommand = new DelegateCommand(() => {
+                renamer.Files = fileList;
+                renamer.rename();
+            }));
+        }
+        private DelegateCommand renameCommand;
+        #endregion
+
     }
 }

--- a/FileRenamer/Views/MainWindow.xaml
+++ b/FileRenamer/Views/MainWindow.xaml
@@ -118,7 +118,7 @@
                         <TextBox Text="{Binding RenameOption.Digits}"/>
                     </StackPanel>
 
-                    <Button Content="Rename"
+                    <Button Content="Apply"
                             Grid.Column="3"
                             Command="{Binding AttachNumberCommand}"
                             />
@@ -159,7 +159,7 @@
                         <TextBox Text="{Binding RenameOption.StringInsertIndex}"/>
                     </StackPanel>
 
-                    <Button Content="Rename"
+                    <Button Content="Aplly"
                             Grid.Column="3"
                             Command="{Binding AttachStringCommand}"
                             />

--- a/FileRenamer/Views/MainWindow.xaml
+++ b/FileRenamer/Views/MainWindow.xaml
@@ -6,10 +6,16 @@
         prism:ViewModelLocator.AutoWireViewModel="True"
         xmlns:models="clr-namespace:FileRenamer.Models"
         Title="{Binding Title}" Height="350" Width="600">
+
+    <Window.InputBindings>
+        <KeyBinding Key="Return" Modifiers="Ctrl" Command="{Binding RenameCommand}" />
+    </Window.InputBindings>
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="auto"/>
             <RowDefinition/>
+            <RowDefinition Height="auto"/>
             <RowDefinition Height="auto"/>
 
         </Grid.RowDefinitions>
@@ -168,6 +174,21 @@
 
             </TabItem>
         </TabControl>
+
+        <Grid Grid.Row="4">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition/>
+                <ColumnDefinition/>
+                <ColumnDefinition/>
+            </Grid.ColumnDefinitions>
+
+            <Button Content="Rename (Ctrl + Enter)"
+                    Grid.Column="2"
+                    Command="{Binding RenameCommand}"
+                    />
+        </Grid>
+
+
 
     </Grid>
 </Window>

--- a/FileRenamerTests/FileRenamerTests.csproj
+++ b/FileRenamerTests/FileRenamerTests.csproj
@@ -45,7 +45,13 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="Prism, Version=8.0.0.1909, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
+      <HintPath>..\packages\Prism.Core.8.0.0.1909\lib\net45\Prism.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/FileRenamerTests/Models/RenamerTests.cs
+++ b/FileRenamerTests/Models/RenamerTests.cs
@@ -32,14 +32,17 @@ namespace FileRenamer.Models.Tests {
 
             Renamer renamer = new Renamer(files);
             renamer.insertString(0, "insert");
+            renamer.rename();
 
             Assert.AreEqual(files[0].Name, "inserttestFile1");
             Assert.AreEqual(files[1].Name, "inserttestFile2");
 
             renamer.insertString(1, "i");
+            renamer.rename();
             Assert.AreEqual(files[0].Name, "iinserttestFile1");
 
             renamer.insertString(50, "x");
+            renamer.rename();
             Assert.AreEqual(files[0].Name, "iinserttestFile1x");
         }
 
@@ -65,6 +68,7 @@ namespace FileRenamer.Models.Tests {
 
             Renamer renamer = new Renamer(files);
             renamer.attachStringToEnd("end");
+            renamer.rename();
             Assert.AreEqual(files[0].Name, "testFile1end");
         }
 
@@ -91,20 +95,24 @@ namespace FileRenamer.Models.Tests {
 
             Renamer renamer = new Renamer(files);
             renamer.insertNumber(0);
+            renamer.rename();
             Assert.AreEqual(files[0].Name, "0testFile0");
             Assert.AreEqual(files[1].Name, "1testFile1");
             Assert.AreEqual(files[10].Name, "10testFile10");
 
             renamer.insertNumber(0, 1, 3);
+            renamer.rename();
             Assert.AreEqual(files[0].Name, "0010testFile0");
             Assert.AreEqual(files[10].Name, "01110testFile10");
 
             files[0].AfterName = "testFile";
             files[0].rename();
             renamer.insertNumber(1, 1, 3);
+            renamer.rename();
             Assert.AreEqual(files[0].Name, "t001estFile");
 
             renamer.attachNumberToEnd(2, 3);
+            renamer.rename();
             Assert.AreEqual(files[0].Name, "t001estFile002");
         }
     }

--- a/FileRenamerTests/packages.config
+++ b/FileRenamerTests/packages.config
@@ -2,4 +2,6 @@
 <packages>
   <package id="MSTest.TestAdapter" version="2.1.1" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="2.1.1" targetFramework="net461" />
+  <package id="Prism.Core" version="8.0.0.1909" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
- 仕様変更 / ファイル名編集のメソッドから実際の rename 処理部を分離
- 機能追加 / AfterName プロパティから変更通知が飛ぶよう実装
- UI変更 / タブコントロール内のボタンのテキストを rename -> apply に変更
- 機能追加 / 実際のリネーム処理が行えるようUIを実装

close #11
