### PR TITLE
ソート機能の実装

### DIFF
--- a/FileRenamer/FileRenamer.csproj
+++ b/FileRenamer/FileRenamer.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Models\ExFileSystemInfo.cs" />
     <Compile Include="Models\RenameOption.cs" />
     <Compile Include="Models\Renamer.cs" />
+    <Compile Include="Models\SortState.cs" />
     <Compile Include="Models\Util.cs" />
     <Compile Include="ViewModels\MainWindowViewModel.cs" />
     <Compile Include="Views\MainWindow.xaml.cs">

--- a/FileRenamer/Models/SortState.cs
+++ b/FileRenamer/Models/SortState.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FileRenamer.Models {
+    public class SortState {
+
+        public FileListColumnName SortColumnName {
+            get => sortColumnName;
+            set {
+                if(value != sortColumnName) {
+                    sortColumnName = value;
+                    sortType = SortType.ASC;
+                }
+                else {
+
+                    switch (sortType) {
+                        case SortType.ASC:
+                            sortType = SortType.DESC;
+                            break;
+
+                        case SortType.DESC:
+                            sortType = SortType.None;
+                            break;
+
+                        case SortType.None:
+                            sortType = SortType.ASC;
+                            break;
+
+                    }
+                }
+            }
+        }
+
+        public List<ExFileSystemInfo> sort(List<ExFileSystemInfo> list) {
+            var l = new List<ExFileSystemInfo>();
+            Func<ExFileSystemInfo, string> func; // ソートの条件を先に格納してソート処理自体は最後に行う。
+
+            switch (SortColumnName) {
+                case FileListColumnName.CurrentName:
+                    func = new Func<ExFileSystemInfo, string>(f => f.Name);
+                    break;
+
+                case FileListColumnName.AfterName:
+                    func = new Func<ExFileSystemInfo, string>(f => f.AfterName);
+                    break;
+
+                case FileListColumnName.Type:
+                    func = new Func<ExFileSystemInfo, string>(f => f.Extension);
+                    break;
+
+                case FileListColumnName.ParentDirectory:
+                    func = new Func<ExFileSystemInfo, string>(f => f.ParentDirectoryName);
+                    break;
+
+                default:
+                    func = new Func<ExFileSystemInfo, string>(f => f.Name);
+                    break;
+            }
+
+            if(sortType == SortType.ASC) {
+                l = list.OrderBy(func).ToList<ExFileSystemInfo>();
+            }
+
+            if(sortType == SortType.DESC) {
+                l = list.OrderByDescending(func).ToList<ExFileSystemInfo>();
+            }
+
+            if(sortType == SortType.None) {
+                l = list.OrderBy(func).ToList<ExFileSystemInfo>();
+            }
+
+            return l;
+        }
+
+        private FileListColumnName sortColumnName;
+        private SortType sortType;
+
+        public enum FileListColumnName {
+            ParentDirectory,
+            CurrentName,
+            AfterName,
+            Type,
+            None
+        }
+
+        private enum SortType {
+            ASC,
+            DESC,
+            None,
+        }
+    }
+}

--- a/FileRenamer/ViewModels/MainWindowViewModel.cs
+++ b/FileRenamer/ViewModels/MainWindowViewModel.cs
@@ -64,11 +64,23 @@ namespace FileRenamer.ViewModels
         private DelegateCommand renameCommand;
         #endregion
 
+
+        public DelegateCommand<string> SortCommand {
+            #region
+            get => sortCommand ?? (sortCommand = new DelegateCommand<string>((string columnName) => {
+                SortColumnName = (FileListColumnName)System.Enum.Parse(typeof(FileListColumnName),columnName);
+                System.Diagnostics.Debug.WriteLine(SortColumnName);
+            }));
+        }
+        private DelegateCommand<string> sortCommand;
+        #endregion
+
+
         public enum FileListColumnName {
             ParentDirectory,
             CurrentName,
             AfterName,
-            Extension,
+            Type,
             None
         }
 

--- a/FileRenamer/ViewModels/MainWindowViewModel.cs
+++ b/FileRenamer/ViewModels/MainWindowViewModel.cs
@@ -3,6 +3,7 @@ using Prism.Commands;
 using Prism.Mvvm;
 using System.Collections.Generic;
 using System.IO;
+using static FileRenamer.Models.SortState;
 
 namespace FileRenamer.ViewModels
 {
@@ -18,6 +19,7 @@ namespace FileRenamer.ViewModels
         public List<ExFileSystemInfo> FileList { get => fileList; set => SetProperty(ref fileList, value); }
 
         private Renamer renamer;
+        private SortState sortState;
 
         public RenameOption RenameOption {
             get => renameOption; set => SetProperty(ref renameOption, value); 
@@ -27,6 +29,7 @@ namespace FileRenamer.ViewModels
 
         public MainWindowViewModel() {
             renamer = new Renamer(FileList);
+            sortState = new SortState();
         }
 
         public FileListColumnName SortColumnName { get => sortColumnName; set => SetProperty(ref sortColumnName, value); }
@@ -68,21 +71,12 @@ namespace FileRenamer.ViewModels
         public DelegateCommand<string> SortCommand {
             #region
             get => sortCommand ?? (sortCommand = new DelegateCommand<string>((string columnName) => {
-                SortColumnName = (FileListColumnName)System.Enum.Parse(typeof(FileListColumnName),columnName);
-                System.Diagnostics.Debug.WriteLine(SortColumnName);
+                FileListColumnName newName = (FileListColumnName)System.Enum.Parse(typeof(FileListColumnName),columnName);
+                sortState.SortColumnName = newName;
+                FileList = sortState.sort(FileList);
             }));
         }
         private DelegateCommand<string> sortCommand;
         #endregion
-
-
-        public enum FileListColumnName {
-            ParentDirectory,
-            CurrentName,
-            AfterName,
-            Type,
-            None
-        }
-
     }
 }

--- a/FileRenamer/ViewModels/MainWindowViewModel.cs
+++ b/FileRenamer/ViewModels/MainWindowViewModel.cs
@@ -29,6 +29,8 @@ namespace FileRenamer.ViewModels
             renamer = new Renamer(FileList);
         }
 
+        public FileListColumnName SortColumnName { get => sortColumnName; set => SetProperty(ref sortColumnName, value); }
+        private FileListColumnName sortColumnName = FileListColumnName.None;
 
         public DelegateCommand AttachNumberCommand {
             #region
@@ -61,6 +63,14 @@ namespace FileRenamer.ViewModels
         }
         private DelegateCommand renameCommand;
         #endregion
+
+        public enum FileListColumnName {
+            ParentDirectory,
+            CurrentName,
+            AfterName,
+            Extension,
+            None
+        }
 
     }
 }

--- a/FileRenamer/Views/MainWindow.xaml
+++ b/FileRenamer/Views/MainWindow.xaml
@@ -23,14 +23,35 @@
 
         <StackPanel Orientation="Horizontal"
                     Grid.Row="0"
-                    Margin="8,0,0,2"
                     x:Name="fileListHeaderStackPanel"
                     >
 
-            <TextBlock Text="parentDirectory" Width="120" />
-            <TextBlock Text="current name" Width="200"/>
-            <TextBlock Text="after name" Width="200"/>
-            <TextBlock Text="type" Width="30"/>
+            <StackPanel.Resources>
+                <Style TargetType="Button">
+
+                    <Setter Property="CommandParameter" 
+                            Value="{Binding RelativeSource={RelativeSource Self},Path=Tag}"
+                            />
+
+                    <Setter Property="Command" Value="{Binding SortCommand}" />
+                </Style>
+            </StackPanel.Resources>
+
+            <Button Content="parentDirectory"
+                    Tag="ParentDirectory"
+                    Width="120" />
+
+            <Button Content="current name"
+                    Tag="CurrentName"
+                    Width="200"/>
+
+            <Button Content="after name"
+                    Tag="AfterName"
+                    Width="200"/>
+
+            <Button Content="type"
+                    Tag="Type"
+                    Width="30"/>
 
         </StackPanel>
 


### PR DESCRIPTION
- ソートの基準としている列を示す enum を定義、追加。
- UI変更 / ソートのUI実装のため、列名を示すテキストブロックをボタンコントロールに変更
- 機能追加 / 列名をクリックでファイルリストを昇、降順ソートできるよう実装

close #13
